### PR TITLE
Make notification-icon-container configurable

### DIFF
--- a/streamlit_custom_notification_box/frontend/src/NotificationBox.tsx
+++ b/streamlit_custom_notification_box/frontend/src/NotificationBox.tsx
@@ -30,7 +30,7 @@ class NotificationBox extends StreamlitComponentBase {
     
     return (
 
-      <div className="notification-icon-container">
+      <div className="notification-icon-container" {...style(styles['notification-icon-container'])}>
         <div className="text-icon-link-close-container" {...style(styles['text-icon-link-close-container'])}>
           <i className="material-icons" {...style(styles['material-icons'])}>{icon}</i>
           <div className="notification-text" {...style(styles['notification-text'])}>{textDisplay}</div>


### PR DESCRIPTION
At the moment ```notification-icon-container``` is hard coded to 30px. It would be great if this can be configurable!